### PR TITLE
Feature/add to cart info

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -58,7 +58,8 @@
     "vtex.product-specifications": "1.x",
     "vtex.modal-layout": "0.x",
     "itgloberspartnercl.whatsapp-button": "0.x",
-    "itgloberspartnercl.bullets-diagramation": "0.x"
+    "itgloberspartnercl.bullets-diagramation": "0.x",
+    "itgloberspartnercl.add-to-cart-info": "0.x"
   },
   "peerDependencies": {
     "vtex.mega-menu": "2.x",

--- a/store/blocks/global/components/PDP - product-info/product-info-data.jsonc
+++ b/store/blocks/global/components/PDP - product-info/product-info-data.jsonc
@@ -27,6 +27,7 @@
             "image#promocion-pdp",
             "rich-text#mensaje",
             "sku-selector",
+            "modal-trigger#add-to-cart-info",
             "product-description",
             "responsive-layout.desktop#buttons__cart--quantity",
             "responsive-layout.mobile#buttons__cart--quantity"
@@ -99,11 +100,6 @@
             "text": "AGREGAR A LA BOLSA"
         }
     },
-    "rich-text#promo": {
-        "props": {
-            "text": "Promocion"
-        }
-    },
     "rich-text#mensaje": {
         "title": "Texto de envio",
         "props": {
@@ -116,5 +112,19 @@
             "collapseContent": true,
             "showTitle": false
         }
+    },
+    "modal-trigger#add-to-cart-info":{
+        "children": [
+            "modal-layout#add-to-cart-info"
+        ],
+        "props": {
+            // "customPixelEventName": "addToCart"
+            "trigger": "load"
+        }
+    },
+    "modal-layout#add-to-cart-info":{
+        "children": [
+            "add-to-cart-info"
+        ]
     }
 }

--- a/store/blocks/global/components/PDP - product-info/product-info-data.jsonc
+++ b/store/blocks/global/components/PDP - product-info/product-info-data.jsonc
@@ -118,8 +118,8 @@
             "modal-layout#add-to-cart-info"
         ],
         "props": {
-            // "customPixelEventName": "addToCart"
-            "trigger": "load"
+            "customPixelEventName": "addToCart"
+            
         }
     },
     "modal-layout#add-to-cart-info":{


### PR DESCRIPTION
Fix: The value to open the modal when giving the add to cart button was changed
|--> description: The value to open the modal when giving the add to cart button was changed and modal is completed
|--> How to test it?: [Workspace](https://crincon--itgloberspartnercl.myvtex.com/sol/p?__device=tablet)
|--> Screenshots or example usage:
**Desktop:**
![image](https://user-images.githubusercontent.com/90701896/218161735-e3fc64b2-f077-4257-afef-1e296adbaa2e.png)

**Mobile**
![image](https://user-images.githubusercontent.com/90701896/218161814-1fa14faf-a9b9-44fa-b8c1-a5ee9415e0a8.png)